### PR TITLE
Updates README.md to reflect the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ The adapter got a `onLayout` method where you can manipulate each `Chip` `View`,
 ## How to use
 ### Gradle
 You can include `ChipView` in your Gradle dependencies via [JitPack](https://jitpack.io/#Plumillon/ChipView).
-Example for the 1.1.4 release :
+Example for the 1.2.0 release :
 ```
 repositories {
         maven { url "https://jitpack.io" }
 }
 
 dependencies {
-        compile 'com.github.Plumillon:ChipView:1.1.4'
+        compile 'com.github.Plumillon:ChipView:1.2.0'
 }
 ```
 


### PR DESCRIPTION
Since most of the users that will include the library in their projects will just copy-paste the Gradle dependency, it is best to have it show the latest version.