### PR TITLE
Remove app_name in Library

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">ChipView Library</string>
-</resources>


### PR DESCRIPTION
- remove app_name field in library
- this can avoid getting the wrong app_name when using this library